### PR TITLE
Add ChildTags

### DIFF
--- a/src/tags/index.ts
+++ b/src/tags/index.ts
@@ -4,6 +4,7 @@ import {
   isCanonical,
   isCommon,
   getParentTags,
+  getChildTags,
 } from "./page-getters";
 import { getTagId, getTagNameFromFeed } from "./works-feed-getters";
 import {
@@ -30,6 +31,7 @@ export const getTag = async ({
     common: isCommon(tagPage),
     canonicalName: getCanonical(tagPage),
     parentTags: getParentTags(tagPage),
+    childTags: getChildTags(tagPage),
   };
 };
 

--- a/src/tags/page-getters.ts
+++ b/src/tags/page-getters.ts
@@ -52,3 +52,15 @@ export const getParentTags = ($tagPage: TagPage) => {
   });
   return parentTags;
 };
+export const getChildTags = ($tagPage: TagPage) => {
+  const childTags: string[] = [];
+  $tagPage(".child > div > ul > li").each((i, element) => {
+
+    //console.log(i, $tagPage(element).children().first().text());
+    let childTag = $tagPage(element).children("a").first().text();
+    if (childTag != '') {
+      childTags.push(childTag);
+    }
+  })
+  return childTags;
+}

--- a/src/tags/page-getters.ts
+++ b/src/tags/page-getters.ts
@@ -54,13 +54,15 @@ export const getParentTags = ($tagPage: TagPage) => {
   return parentTags;
 };
 export const getChildTags = ($tagPage: TagPage) => {
-  const childTags: string[] = [];
+  const childTags: {tagName: string; Category: TagCategory }[] = [];
   $tagPage(".child > div > ul > li").each((i, element) => {
-
-    //console.log(i, $tagPage(element).children().first().text());
     let childTag = $tagPage(element).children("a").first().text();
     if (childTag != '') {
-      childTags.push(childTag);
+      // parent and parent's parent is an element
+      let classcatagory = (element.parent?.parent as Element).attributes[0].value.split(' ')[0]
+      //console.log(classcatagory != 'freeforms' ? classcatagory : 'additional tags');
+      let tc = (classcatagory != 'freeforms' ? classcatagory : 'additional tags') as TagCategory;
+      childTags.push({tagName: childTag, Category: tc});
     }
   })
   return childTags;

--- a/src/tags/page-getters.ts
+++ b/src/tags/page-getters.ts
@@ -60,7 +60,7 @@ export const getChildTags = ($tagPage: TagPage) => {
     const category = (className !== "freeforms" ? className : "additional tags") as TagCategory;
     return $div.find("ul > li a").map((_, aElement) => {
       const childTag = $tagPage(aElement).text();
-      return childTag ? { tagName: childTag, Category: category} : null;
+      return childTag ? { tagName: childTag, category: category} : null;
     }).get();
   }).get();
 }

--- a/src/tags/page-getters.ts
+++ b/src/tags/page-getters.ts
@@ -54,7 +54,9 @@ export const getParentTags = ($tagPage: TagPage) => {
   return parentTags;
 };
 export const getChildTags = ($tagPage: TagPage) => {
+
   const childTags: {tagName: string; Category: TagCategory }[] = [];
+  /*
   $tagPage(".child > div > ul > li").each((i, element) => {
     let childTag = $tagPage(element).children("a").first().text();
     if (childTag != '') {
@@ -65,6 +67,18 @@ export const getChildTags = ($tagPage: TagPage) => {
       childTags.push({tagName: childTag, Category: tc});
     }
   })
+  */
+
+  const divCategory = $tagPage(".child > div");
+  divCategory.each((i, divelement) => {
+    let classcatagory = divelement.attribs?.class?.split(' ')[0];
+    let tagcatagory = (classcatagory != 'freeforms' ? classcatagory : 'additional tags') as TagCategory;
+    $tagPage(divelement).find('ul > li a').each((_, aElement) => {
+      let childTag = $tagPage(aElement).text();
+      (childTag != '') && childTags.push({tagName: childTag, Category: tagcatagory});
+    })
+  })
+
   return childTags;
 }
 

--- a/src/tags/page-getters.ts
+++ b/src/tags/page-getters.ts
@@ -54,32 +54,15 @@ export const getParentTags = ($tagPage: TagPage) => {
   return parentTags;
 };
 export const getChildTags = ($tagPage: TagPage) => {
-
-  const childTags: {tagName: string; Category: TagCategory }[] = [];
-  /*
-  $tagPage(".child > div > ul > li").each((i, element) => {
-    let childTag = $tagPage(element).children("a").first().text();
-    if (childTag != '') {
-      // parent and parent's parent is an element
-      let classcatagory = (element.parent?.parent as Element).attributes[0].value.split(' ')[0]
-      //console.log(classcatagory != 'freeforms' ? classcatagory : 'additional tags');
-      let tc = (classcatagory != 'freeforms' ? classcatagory : 'additional tags') as TagCategory;
-      childTags.push({tagName: childTag, Category: tc});
-    }
-  })
-  */
-
-  const divCategory = $tagPage(".child > div");
-  divCategory.each((i, divelement) => {
-    let classcatagory = divelement.attribs?.class?.split(' ')[0];
-    let tagcatagory = (classcatagory != 'freeforms' ? classcatagory : 'additional tags') as TagCategory;
-    $tagPage(divelement).find('ul > li a').each((_, aElement) => {
-      let childTag = $tagPage(aElement).text();
-      (childTag != '') && childTags.push({tagName: childTag, Category: tagcatagory});
-    })
-  })
-
-  return childTags;
+  return $tagPage(".child > div").map((_, divElement) => {
+    const $div = $tagPage(divElement);
+    const className = $div.attr("class")?.split(' ')[0] ?? "";
+    const category = (className !== "freeforms" ? className : "additional tags") as TagCategory;
+    return $div.find("ul > li a").map((_, aElement) => {
+      const childTag = $tagPage(aElement).text();
+      return childTag ? { tagName: childTag, Category: category} : null;
+    }).get();
+  }).get();
 }
 
 export const getSubTags = ($tagPage: TagPage) => {

--- a/types/entities.ts
+++ b/types/entities.ts
@@ -18,6 +18,7 @@ export interface Tag {
   // common and cannot be filtered on.
   canonicalName: string | null;
   parentTags: string[];
+  childTags: string[];
 }
 
 export interface User {

--- a/types/entities.ts
+++ b/types/entities.ts
@@ -20,7 +20,7 @@ export interface Tag {
   parentTags: string[];
   childTags: Array<{
     tagName: string;
-    Category: TagCategory;
+    category: TagCategory;
   }>;
   subTags: Array<{
     tagName: string;

--- a/types/entities.ts
+++ b/types/entities.ts
@@ -18,7 +18,10 @@ export interface Tag {
   // common and cannot be filtered on.
   canonicalName: string | null;
   parentTags: string[];
-  childTags: string[];
+  childTags: Array<{
+    tagName: string;
+    Category: TagCategory;
+  }>;
   subTags: Array<{
     tagName: string;
     parentSubTag: string | null;


### PR DESCRIPTION
Adds getChildTags function to tags/page-getters.ts
subTags type is an array of strings added to entities.ts

Tests need to be added but I'm unfamiliar with it so it will take me some time.

This is lowkey quick and dirty, I'm not happy that we're just discarding the category data, maybe i make subtag an array of {tagname: string, catagory: TagCatagory}

This is the same as #82 but I fixed the git history.