### PR TITLE
Fixing link syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,4 +221,4 @@ The logging will help you understand what's going on, but it's by no mean necess
 
 # How do I help?
 
-See (CONTRIBUTE.md)[CONTRIBUTE.md].
+See [CONTRIBUTE.md](CONTRIBUTE.md).


### PR DESCRIPTION
The link to `CONTRIBUTE.md` had its Markdown syntax switched, so it didn't work.