### PR TITLE
Updates tsconfig lib option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "types": ["node", "@types/jest"],
     "moduleResolution": "Node",
     "module": "es2022",
+    "lib":["es2022"],
     "paths": {
       "src/*": ["./src/*"],
       "types/*": ["./types/*"]


### PR DESCRIPTION
Now the warning for using String.prototype.replaceAll will be no more

Creating as a pull request in case there are any other config options (in or outside of tsconfig, or build, or whatever) to consider that have been put off.